### PR TITLE
Safer Accessing of Layers

### DIFF
--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -221,7 +221,10 @@ impl AsepriteFile<'_> {
         let frame = &self.frames[frame_index];
 
         for cel in frame.cels.iter() {
-            let layer = &self.layers[cel.layer_index];
+            let layer = match self.layers.get(cel.layer_index) {
+                Some(l) => l,
+                None => continue,
+            };
             if !layer.visible {
                 continue;
             }

--- a/src/loader/mod.rs
+++ b/src/loader/mod.rs
@@ -82,6 +82,7 @@ pub struct Layer {
     pub opacity: u8,
     pub blend_mode: BlendMode,
     pub visible: bool,
+    pub layer_type: LayerType,
 }
 
 impl AsepriteFile<'_> {
@@ -94,12 +95,13 @@ impl AsepriteFile<'_> {
             .layers
             .iter()
             .filter_map(|layer| {
-                if layer.layer_type == LayerType::Normal {
+                if layer.layer_type == LayerType::Normal || layer.layer_type == LayerType::Group {
                     Some(Layer {
                         name: layer.name.to_string(),
                         opacity: layer.opacity,
                         blend_mode: layer.blend_mode,
                         visible: layer.flags.contains(LayerFlags::VISIBLE),
+                        layer_type: layer.layer_type,
                     })
                 } else {
                     None
@@ -225,7 +227,7 @@ impl AsepriteFile<'_> {
                 Some(l) => l,
                 None => continue,
             };
-            if !layer.visible {
+            if !layer.visible || layer.layer_type == LayerType::Group {
                 continue;
             }
 


### PR DESCRIPTION
~~I ran into an issue that I'm mostly certain is related to having groups of layers. Using the image in question on the existing source, has an invalid layer_index for every group of layers that exists. Flattening each of those groups allows the image to be parsed correctly by this function. I'm not totally confident this is the best solution for the problem, but it does resolve my issue at least and I don't think group layers are important for anything.~~

Heh, read just a few lines more into the source and realized that layer groups are being skipped when adding the layers, so this makes total sense. I've added code that keeps these, let me know if this is how you want to proceed.

Thanks for the crate!